### PR TITLE
fix: corepack proxy

### DIFF
--- a/.github/actions/build-rspack/action.yaml
+++ b/.github/actions/build-rspack/action.yaml
@@ -29,12 +29,10 @@ runs:
     - shell: bash
       name: Install package manager
       run: |
-        npm install -g corepack@latest
+        npm install -g corepack@0.24.1
         echo "Corepack version: $(corepack --version)"
         corepack enable
 
-    - shell: bash
-      run: pnpm --version
     - name: Checkout Rspack repo
       uses: actions/checkout@v4
       with:

--- a/.github/actions/build-rspack/action.yaml
+++ b/.github/actions/build-rspack/action.yaml
@@ -27,7 +27,12 @@ runs:
       with:
         node-version: 18
     - shell: bash
-      run: corepack enable
+      name: Install package manager
+      run: |
+        npm install -g corepack@latest
+        echo "Corepack version: $(corepack --version)"
+        corepack enable
+
     - shell: bash
       run: pnpm --version
     - name: Checkout Rspack repo

--- a/.github/actions/prepare-rspack-binding/action.yaml
+++ b/.github/actions/prepare-rspack-binding/action.yaml
@@ -33,8 +33,11 @@ runs:
       with:
         node-version: ${{ inputs.node-version }}
     - shell: bash
+      name: Install package manager
       run: |
         cd ${{ inputs.path }}
+        npm install -g corepack@latest
+        echo "Corepack version: $(corepack --version)"
         corepack enable
     - shell: bash
       run: |

--- a/.github/actions/prepare-rspack-binding/action.yaml
+++ b/.github/actions/prepare-rspack-binding/action.yaml
@@ -36,13 +36,9 @@ runs:
       name: Install package manager
       run: |
         cd ${{ inputs.path }}
-        npm install -g corepack@latest
+        npm install -g corepack@0.24.1
         echo "Corepack version: $(corepack --version)"
         corepack enable
-    - shell: bash
-      run: |
-        cd ${{ inputs.path }}
-        pnpm --version
     - id: rust-cache
       uses: MasterworksIO/action-local-cache@2
       with:


### PR DESCRIPTION
Install latest `corepack` to install package manager behind a corporative proxy.

> As of Corepack 0.26.0, we're now using [proxy-from-env](https://github.com/Rob--W/proxy-from-env#readme). It should not require anything to install on your end, only setting env variable AFAIK (so HTTPS_PROXY, or ALL_PROXY). I recommend opening a new issue if you're need more help.

From: https://github.com/nodejs/corepack/issues/67#issuecomment-1980726187

**But** when i installed corepack@0.26.0 it is not working. You can reference the related bug report here: https://github.com/nodejs/corepack/pull/451 .

**So** we should lock `corepack` with 0.24.1 version.