### PR TITLE
chore: disable nx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             os: ubuntu-latest
           - suite: _selftest
             os: ubuntu-latest
-          # - suite: nx
-          #   os: ubuntu-latest
+          - suite: nx
+            os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rsbuild

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,8 +30,8 @@ jobs:
             os: ubuntu-latest
           - suite: _selftest
             os: ubuntu-latest
-          - suite: nx
-            os: ubuntu-latest
+          # - suite: nx
+          #   os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rsbuild

--- a/.github/workflows/ecosystem-ci-from-commit.yml
+++ b/.github/workflows/ecosystem-ci-from-commit.yml
@@ -25,7 +25,7 @@ on:
         options:
           - "-"
           - modernjs
-          - nx
+          # - nx
           - rspress
           - rslib
           - rsbuild
@@ -92,8 +92,8 @@ jobs:
             os: ubuntu-latest
           - suite: _selftest
             os: ubuntu-latest
-          - suite: nx
-            os: ubuntu-latest
+          # - suite: nx
+          #   os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib

--- a/.github/workflows/ecosystem-ci-from-commit.yml
+++ b/.github/workflows/ecosystem-ci-from-commit.yml
@@ -25,7 +25,7 @@ on:
         options:
           - "-"
           - modernjs
-          # - nx
+          - nx
           - rspress
           - rslib
           - rsbuild
@@ -92,8 +92,8 @@ jobs:
             os: ubuntu-latest
           - suite: _selftest
             os: ubuntu-latest
-          # - suite: nx
-          #   os: ubuntu-latest
+          - suite: nx
+            os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib
@@ -109,6 +109,7 @@ jobs:
     name: execute-all (${{ matrix.suite }})
     steps:
       - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
       - uses: ./.github/actions/build-rspack
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -30,7 +30,7 @@ on:
         options:
           - "-"
           - modernjs
-          - nx
+          # - nx
           - rspress
           - rsbuild
           - rslib
@@ -118,8 +118,8 @@ jobs:
         include:
           - suite: modernjs
             os: ubuntu-latest
-          - suite: nx
-            os: ubuntu-latest
+          # - suite: nx
+          #   os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -30,7 +30,7 @@ on:
         options:
           - "-"
           - modernjs
-          # - nx
+          - nx
           - rspress
           - rsbuild
           - rslib
@@ -118,8 +118,8 @@ jobs:
         include:
           - suite: modernjs
             os: ubuntu-latest
-          # - suite: nx
-          #   os: ubuntu-latest
+          - suite: nx
+            os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib
@@ -135,6 +135,7 @@ jobs:
     name: execute-all (${{ matrix.suite }})
     steps:
       - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
       - uses: ./.github/actions/build-rspack
         with:
           repository: ${{ inputs.repo }}

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -36,7 +36,7 @@ on:
         options:
           - "-"
           - modernjs
-          - nx
+          # - nx
           - rspress
           - rsbuild
           - rslib
@@ -114,8 +114,8 @@ jobs:
         include:
           - suite: modernjs
             os: ubuntu-latest
-          - suite: nx
-            os: ubuntu-latest
+          # - suite: nx
+          #   os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -36,7 +36,7 @@ on:
         options:
           - "-"
           - modernjs
-          - nx
+          # - nx
           - rspress
           - rsbuild
           - rslib
@@ -115,8 +115,8 @@ jobs:
         include:
           - suite: modernjs
             os: ubuntu-latest
-          - suite: nx
-            os: ubuntu-latest
+          # - suite: nx
+          #   os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -36,7 +36,7 @@ on:
         options:
           - "-"
           - modernjs
-          # - nx
+          - nx
           - rspress
           - rsbuild
           - rslib
@@ -81,6 +81,7 @@ jobs:
     if: "inputs.suite != '-'"
     steps:
       - uses: actions/checkout@v4
+      - uses: moonrepo/setup-rust@v1
       - uses: ./.github/actions/build-rspack
         with:
           ref: ${{ inputs.suiteRef }}
@@ -114,8 +115,8 @@ jobs:
         include:
           - suite: modernjs
             os: ubuntu-latest
-          # - suite: nx
-          #   os: ubuntu-latest
+          - suite: nx
+            os: ubuntu-latest
           - suite: rspress
             os: ubuntu-latest
           - suite: rslib

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -7,11 +7,12 @@ export async function test(options: RunOptions) {
 		repo: 'nrwl/nx',
 		branch: 'master',
 		beforeTest: async () => {
+			await $`export NX_DAEMON=false`
 			await $`cargo build`
-			await $`export NX_DAEMON=false; pnpm run build --skip-nx-cache`
+			await $`pnpm run build --skip-nx-cache`
 		},
 		test: [
-			'export NX_DAEMON=false; pnpm nx test --skip-nx-cache rspack',
+			'pnpm nx test --skip-nx-cache rspack',
 			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -1,15 +1,19 @@
-import { runInRepo } from '../utils'
+import { runInRepo, $ } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		repo: 'nrwl/nx-labs',
+		repo: 'nrwl/nx',
 		branch: 'main',
-		build: ['yarn nx build --skip-nx-cache rspack'],
+		build: ['pnpm nx build --skip-nx-cache rspack'],
+		beforeTest: async () => {
+			await $`cargo build`
+			await $`pnpm run build`
+		},
 		test: [
-			'yarn nx test --skip-nx-cache rspack',
-			'yarn nx e2e --skip-nx-cache rspack-e2e',
+			'pnpm nx test --skip-nx-cache rspack',
+			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})
 }

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -5,7 +5,7 @@ export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
 		repo: 'nrwl/nx',
-		branch: 'main',
+		branch: 'master',
 		build: ['pnpm nx build --skip-nx-cache rspack'],
 		beforeTest: async () => {
 			await $`cargo build`

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -11,7 +11,7 @@ export async function test(options: RunOptions) {
 			await $`export NX_DAEMON=false; pnpm run build --skip-nx-cache`
 		},
 		test: [
-			'pnpm nx test --skip-nx-cache rspack',
+			'export NX_DAEMON=false; pnpm nx test --skip-nx-cache rspack',
 			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -8,7 +8,7 @@ export async function test(options: RunOptions) {
 		branch: 'master',
 		beforeTest: async () => {
 			await $`cargo build`
-			await $`pnpm run build`
+			await $`pnpm run build --skip-nx-cache`
 		},
 		test: [
 			'pnpm nx test --skip-nx-cache rspack',

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -9,7 +9,7 @@ export async function test(options: RunOptions) {
 		beforeTest: async () => {
 			await $`cargo build`
 			await $`pnpm nx reset`
-			await $`pnpm run build rspack --skip-nx-cache --verbose`
+			await $`pnpm nx build rspack --skip-nx-cache --verbose`
 		},
 		test: [
 			'pnpm nx test rspack --skip-nx-cache --verbose',

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -8,10 +8,11 @@ export async function test(options: RunOptions) {
 		branch: 'master',
 		beforeTest: async () => {
 			await $`cargo build`
-			await $`pnpm run build --skip-nx-cache --verbose`
+			await $`pnpm nx reset`
+			await $`pnpm run build rspack --skip-nx-cache --verbose`
 		},
 		test: [
-			'pnpm nx test --skip-nx-cache rspack --verbose',
+			'pnpm nx test rspack --skip-nx-cache --verbose',
 			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -6,7 +6,6 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'nrwl/nx',
 		branch: 'master',
-		build: ['pnpm nx build --skip-nx-cache rspack'],
 		beforeTest: async () => {
 			await $`cargo build`
 			await $`pnpm run build`

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -8,7 +8,7 @@ export async function test(options: RunOptions) {
 		branch: 'master',
 		beforeTest: async () => {
 			await $`cargo build`
-			await $`pnpm run build --skip-nx-cache`
+			await $`export NX_DAEMON=false; pnpm run build --skip-nx-cache`
 		},
 		test: [
 			'pnpm nx test --skip-nx-cache rspack',

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -8,10 +8,10 @@ export async function test(options: RunOptions) {
 		branch: 'master',
 		beforeTest: async () => {
 			await $`cargo build`
-			await $`pnpm run build --skip-nx-cache`
+			await $`pnpm run build --skip-nx-cache --verbose`
 		},
 		test: [
-			'pnpm nx test --skip-nx-cache rspack',
+			'pnpm nx test --skip-nx-cache rspack --verbose',
 			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -7,12 +7,11 @@ export async function test(options: RunOptions) {
 		repo: 'nrwl/nx',
 		branch: 'master',
 		beforeTest: async () => {
-			await $`export NX_DAEMON=false`
 			await $`cargo build`
-			await $`pnpm run build --skip-nx-cache`
+			await $`NX_DAEMON=false pnpm run build --skip-nx-cache`
 		},
 		test: [
-			'pnpm nx test --skip-nx-cache rspack',
+			'NX_DAEMON=false pnpm nx test --skip-nx-cache rspack',
 			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})

--- a/tests/nx.ts
+++ b/tests/nx.ts
@@ -8,10 +8,10 @@ export async function test(options: RunOptions) {
 		branch: 'master',
 		beforeTest: async () => {
 			await $`cargo build`
-			await $`NX_DAEMON=false pnpm run build --skip-nx-cache`
+			await $`pnpm run build --skip-nx-cache`
 		},
 		test: [
-			'NX_DAEMON=false pnpm nx test --skip-nx-cache rspack',
+			'pnpm nx test --skip-nx-cache rspack',
 			// 'pnpm nx run-many -t e2e-local -p e2e-rspack --skip-nx-cache',
 		],
 	})


### PR DESCRIPTION
Try to upgrade nx eco-ci but faild with errors below:

```
 NX   Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it. See errors below.
  
  Failed to process project graph. Run "nx reset" to fix this. Please report the issue if you keep seeing it.
        WorkspaceValidityError: Configuration Error
    The following implicitDependencies point to non-existent project(s):
      create-nx-workspace
        workspace
        at assertWorkspaceValidity (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/utils/assert-workspace-validity.js:71:11)
        at buildProjectGraphUsingProjectFileMap (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/project-graph/build-project-graph.js:57:65)
        at buildProjectGraphAndSourceMapsWithoutDaemon (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/project-graph/project-graph.js:101:99)
        at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
        at async createProjectGraphAndSourceMapsAsync (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/project-graph/project-graph.js:208:25)
        at async createProjectGraphAsync (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/project-graph/project-graph.js:198:39)
        at async Object.runOne (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/command-line/run/run-one.js:24:26)
        at async handleErrors (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/utils/handle-errors.js:9:24)
        at async Object.handler (/home/runner/work/rspack-ecosystem-ci/rspack-ecosystem-ci/workspace/nx/nx/node_modules/.pnpm/nx@19.8.0-beta.2_@swc-node+register@1.9.1_@swc+core@1.5.7_@swc+helpers@0.5.11__@swc+types@0.1_cubwuss6rao5ft2z25wlmuz63m/node_modules/nx/src/command-line/run/command-object.js:32:26)
```

But the same commands run perfectly on my own macos machine, can not figure out why this happens.

So just disable nx eco-ci and wait for a futhur researching of nx project.