### PR TITLE
fix: playwright install warning in rsbuild

### DIFF
--- a/tests/rsbuild.ts
+++ b/tests/rsbuild.ts
@@ -8,7 +8,7 @@ export async function test(options: RunOptions) {
 		branch: process.env.RSBUILD_REF ?? 'main',
 		beforeTest: async () => {
 			cd('./e2e')
-			await $`pnpm playwright install --with-deps`
+			await $`npx playwright install`
 			cd('..')
 		},
 		test: ['e2e:rspack'],


### PR DESCRIPTION
Failed to install browsers
Error: Installation process exited with code: 100