### PR TITLE
chore: degrade the ubuntu version to 22.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,25 +27,25 @@ jobs:
       matrix:
         include:
           - suite: modernjs
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: _selftest
-            os: ubuntu-latest
+            os: ubuntu-22.04
           # - suite: nx
-          #   os: ubuntu-latest
+          #   os: ubuntu-22.04
           - suite: rspress
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsbuild
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: examples
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rslib
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsdoctor
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: devserver
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: nuxt
-            os: ubuntu-latest
+            os: ubuntu-22.04
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.suite }}

--- a/.github/workflows/ecosystem-ci-from-commit.yml
+++ b/.github/workflows/ecosystem-ci-from-commit.yml
@@ -64,7 +64,7 @@ jobs:
           ref: ${{ inputs.commitSHA }}
 
   execute-selected-suite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: [get-runner-labels, prepare-binding]
     if: "inputs.suite != '-'"
     steps:
@@ -89,25 +89,25 @@ jobs:
       matrix:
         include:
           - suite: modernjs
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: _selftest
-            os: ubuntu-latest
+            os: ubuntu-22.04
           # - suite: nx
-          #   os: ubuntu-latest
+          #   os: ubuntu-22.04
           - suite: rsdoctor
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rspress
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rslib
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsbuild
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: examples
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: devserver
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: nuxt
-            os: ubuntu-latest
+            os: ubuntu-22.04
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: execute-all (${{ matrix.suite }})

--- a/.github/workflows/ecosystem-ci-from-pr.yml
+++ b/.github/workflows/ecosystem-ci-from-pr.yml
@@ -69,7 +69,7 @@ jobs:
           ref: ${{ inputs.branchName }}
 
   execute-selected-suite:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     needs: prepare-binding
     if: "inputs.suite != '-'"
     steps:
@@ -94,23 +94,23 @@ jobs:
       matrix:
         include:
           - suite: modernjs
-            os: ubuntu-latest
+            os: ubuntu-22.04
           # - suite: nx
-          #   os: ubuntu-latest
+          #   os: ubuntu-22.04
           - suite: rspress
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rslib
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsbuild
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsdoctor
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: examples
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: devserver
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: nuxt
-            os: ubuntu-latest
+            os: ubuntu-22.04
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: execute-all (${{ matrix.suite }})

--- a/.github/workflows/ecosystem-ci-selected.yml
+++ b/.github/workflows/ecosystem-ci-selected.yml
@@ -78,7 +78,7 @@ jobs:
 
   execute-selected-suite:
     needs: prepare-binding
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     if: "inputs.suite != '-'"
     steps:
       - uses: actions/checkout@v4
@@ -115,23 +115,23 @@ jobs:
       matrix:
         include:
           - suite: modernjs
-            os: ubuntu-latest
+            os: ubuntu-22.04
           # - suite: nx
-          #   os: ubuntu-latest
+          #   os: ubuntu-22.04
           - suite: rspress
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rslib
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsbuild
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: rsdoctor
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: examples
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: devserver
-            os: ubuntu-latest
+            os: ubuntu-22.04
           - suite: nuxt
-            os: ubuntu-latest
+            os: ubuntu-22.04
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: execute-all (${{ matrix.suite }})

--- a/.github/workflows/get-runner-labels.yml
+++ b/.github/workflows/get-runner-labels.yml
@@ -16,7 +16,7 @@ on:
 jobs:
   main:
     name: Get Runner Labels
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     outputs:
       LINUX_RUNNER_LABELS: ${{ steps.run.outputs.LINUX_RUNNER_LABELS }}
       MACOS_RUNNER_LABELS: ${{ steps.run.outputs.MACOS_RUNNER_LABELS }}
@@ -26,6 +26,6 @@ jobs:
         shell: bash
         run: |
           # set default value for vars.XXX_RUNNER_LABELS
-          echo 'LINUX_RUNNER_LABELS=${{ vars.LINUX_RUNNER_LABELS || '"ubuntu-latest"' }}' >> "$GITHUB_OUTPUT"
+          echo 'LINUX_RUNNER_LABELS=${{ vars.LINUX_RUNNER_LABELS || '"ubuntu-22.04"' }}' >> "$GITHUB_OUTPUT"
           echo 'MACOS_RUNNER_LABELS=${{ vars.MACOS_RUNNER_LABELS || '"macos-latest"' }}' >> "$GITHUB_OUTPUT"
           echo 'WINDOWS_RUNNER_LABELS=${{ vars.WINDOWS_RUNNER_LABELS || '"windows-latest"' }}' >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
<img width="1350" alt="image" src="https://github.com/user-attachments/assets/c5f942f7-e785-450e-9f26-49bec46a9c23" />
This is because the ubuntu 24, so we need to degrade this, like the ci in rspack repo.

https://github.com/web-infra-dev/rspack/blob/main/.github/workflows/ecosystem-ci.yml#L131
https://github.com/rspack-contrib/rspack-ecosystem-ci/pull/69#issuecomment-2609684001