### PR TITLE
chore:  workaround override error  rspack ecosystem-ci

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -496,9 +496,9 @@ async function applyPackageOverrides(
 		}
 
 		if (pkg.packageManager?.includes('pnpm@10')) {
-			pkg.packageManager = 'pnpm@10.1.0'
+			pkg.packageManager = 'pnpm@9.15.9'
 			if (pkg.engines?.pnpm) {
-				pkg.engines.pnpm = '>=10.1.0'
+				pkg.engines.pnpm = '>=9.15.9'
 			}
 		}
 	} else if (pm === 'yarn') {

--- a/utils.ts
+++ b/utils.ts
@@ -494,6 +494,13 @@ async function applyPackageOverrides(
 			...pkg.pnpm.overrides,
 			...overrides,
 		}
+
+		if (pkg.packageManager?.includes('pnpm@10')) {
+			pkg.packageManager = 'pnpm@10.1.0'
+			if (pkg.engines?.pnpm) {
+				pkg.engines.pnpm = '>=10.1.0'
+			}
+		}
 	} else if (pm === 'yarn') {
 		if (!pkg.devDependencies) {
 			pkg.devDependencies = {}


### PR DESCRIPTION
[bug of pnpm@10](https://github.com/pnpm/pnpm/issues/9270) cause this problem.
Now, just make workaround for this by downgrade to pnpm@9
