### PR TITLE
ci: enable lynx-stack suite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Lint
         if: matrix.suite == '_selftest'
         run: pnpm lint
+      - name: Setup Node.js
+        if: matrix.suite == 'lynx-stack'
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
       - name: Setup Rust
         if: matrix.suite == 'lynx-stack'
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -48,6 +48,8 @@ jobs:
             os: ubuntu-22.04
           - suite: plugin
             os: ubuntu-22.04
+          - suite: lynx-stack
+            os: ubuntu-22.04
       fail-fast: false
     runs-on: ${{ matrix.os }}
     name: ${{ matrix.suite }}
@@ -62,6 +64,9 @@ jobs:
       - name: Lint
         if: matrix.suite == '_selftest'
         run: pnpm lint
+      - name: Setup Rust
+        if: matrix.suite == 'lynx-stack'
+        uses: actions-rust-lang/setup-rust-toolchain@v1
       - name: Expose GitHub Runtime
         uses: crazy-max/ghaction-github-runtime@v3
       - run: >-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,7 +65,7 @@ jobs:
         if: matrix.suite == '_selftest'
         run: pnpm lint
       - name: Setup Node.js
-        if: matrix.suite == 'lynx-stack'
+        if: matrix.suite == 'lynx-stack' || matrix.suite == '_selftest'
         uses: actions/setup-node@v4
         with:
           node-version: 22

--- a/rspack-package.json
+++ b/rspack-package.json
@@ -17,6 +17,10 @@
 		{
 			"name": "@rspack/tracing",
 			"directory": "packages/rspack-tracing"
+		},
+		{
+			"name": "@rspack/test-tools",
+			"directory": "packages/rsapck-test-tools"
 		}
 	],
 	"npm": {

--- a/rspack-package.json
+++ b/rspack-package.json
@@ -20,7 +20,7 @@
 		},
 		{
 			"name": "@rspack/test-tools",
-			"directory": "packages/rsapck-test-tools"
+			"directory": "packages/rspack-test-tools"
 		}
 	],
 	"npm": {

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -1,11 +1,29 @@
-import { runInRepo } from '../utils'
+import fs from 'node:fs'
+import path from 'node:path'
+
+import { runInRepo, $ } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		repo: 'lynx-family/lynx-stack',
-		branch: process.env.LYNX_STACK_REF ?? 'main',
+		// TODO: debug only, should change to lynx-family/lynx-stack
+		repo: 'colinaaa/lynx-stack',
+		branch: process.env.LYNX_STACK_REF ?? 'colin/0404/uqr',
+		async beforeInstall() {
+			const lynxStackDir = path.resolve(process.cwd(), 'workspace/lynx-stack')
+			const packageJsonPath = path.join(lynxStackDir, 'package.json')
+			const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
+
+			// Copy Rspack version from pnpm overrides to devDependencies
+			// lynx-stack would override the rspack version to the version in devDependencies using "overrides."
+			if (packageJson.pnpm?.overrides?.['@rspack/core']) {
+				packageJson.devDependencies = packageJson.devDependencies || {}
+				packageJson.devDependencies['@rspack/core'] =
+					packageJson.pnpm.overrides['@rspack/core']
+				fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
+			}
+		},
 		beforeBuild: `rustup target add wasm32-unknown-unknown`,
 		// TODO(colinaaa): enable Lynx for Web tests
 		build: 'pnpm turbo build',

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -1,11 +1,12 @@
 import { mkdtemp } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
+import { join } from 'node:path'
 
 import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
-	const tmp = await mkdtemp(tmpdir())
+	const tmp = await mkdtemp(join(tmpdir(), 'lynx-stack-'))
 
 	await runInRepo({
 		...options,

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -6,6 +6,7 @@ export async function test(options: RunOptions) {
 		...options,
 		repo: 'lynx-family/lynx-stack',
 		branch: process.env.LYNX_STACK_REF ?? 'main',
+		beforeBuild: `rustup target add wasm32-unknown-unknown`,
 		// TODO(colinaaa): enable Lynx for Web tests
 		build: 'pnpm turbo build',
 		test: 'test',

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -1,32 +1,11 @@
-import fs from 'node:fs'
-import path from 'node:path'
-
 import { runInRepo, $ } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
 	await runInRepo({
 		...options,
-		// TODO: debug only, should change to lynx-family/lynx-stack
-		repo: 'colinaaa/lynx-stack',
-		branch: process.env.LYNX_STACK_REF ?? 'colin/0404/uqr',
-		async beforeInstall() {
-			const lynxStackDir = path.resolve(
-				process.cwd(),
-				'workspace/lynx-stack/lynx-stack',
-			)
-			const packageJsonPath = path.join(lynxStackDir, 'package.json')
-			const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
-
-			// Copy Rspack version from pnpm overrides to devDependencies
-			// lynx-stack would override the rspack version to the version in devDependencies using "overrides."
-			if (packageJson.pnpm?.overrides?.['@rspack/core']) {
-				packageJson.devDependencies = packageJson.devDependencies || {}
-				packageJson.devDependencies['@rspack/core'] =
-					packageJson.pnpm.overrides['@rspack/core']
-				fs.writeFileSync(packageJsonPath, JSON.stringify(packageJson, null, 2))
-			}
-		},
+		repo: 'lynx-family/lynx-stack',
+		branch: process.env.LYNX_STACK_REF ?? 'main',
 		beforeBuild: `rustup target add wasm32-unknown-unknown`,
 		// TODO(colinaaa): enable Lynx for Web tests
 		build: 'pnpm turbo build',

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -1,9 +1,15 @@
+import { mkdtemp } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+
 import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
+	const tmp = await mkdtemp(tmpdir())
+
 	await runInRepo({
 		...options,
+		workspace: tmp,
 		repo: 'lynx-family/lynx-stack',
 		branch: process.env.LYNX_STACK_REF ?? 'main',
 		beforeBuild: `rustup target add wasm32-unknown-unknown`,

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -11,7 +11,10 @@ export async function test(options: RunOptions) {
 		repo: 'colinaaa/lynx-stack',
 		branch: process.env.LYNX_STACK_REF ?? 'colin/0404/uqr',
 		async beforeInstall() {
-			const lynxStackDir = path.resolve(process.cwd(), 'workspace/lynx-stack')
+			const lynxStackDir = path.resolve(
+				process.cwd(),
+				'workspace/lynx-stack/lynx-stack',
+			)
 			const packageJsonPath = path.join(lynxStackDir, 'package.json')
 			const packageJson = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'))
 

--- a/tests/lynx-stack.ts
+++ b/tests/lynx-stack.ts
@@ -1,4 +1,4 @@
-import { runInRepo, $ } from '../utils'
+import { runInRepo } from '../utils'
 import { RunOptions } from '../types'
 
 export async function test(options: RunOptions) {
@@ -9,6 +9,6 @@ export async function test(options: RunOptions) {
 		beforeBuild: `rustup target add wasm32-unknown-unknown`,
 		// TODO(colinaaa): enable Lynx for Web tests
 		build: 'pnpm turbo build',
-		test: 'test',
+		test: 'pnpm run test --silent',
 	})
 }

--- a/utils.ts
+++ b/utils.ts
@@ -460,7 +460,7 @@ async function applyPackageOverrides(
 	beforeInstallCommand: ((scripts: any) => Promise<any>) | void,
 ) {
 	const useFileProtocol = (v: string) =>
-		isLocalOverride(v) ? path.resolve(v) : v
+		isLocalOverride(v) ? `file:${path.resolve(v)}` : v
 	// remove boolean flags
 	overrides = Object.fromEntries(
 		Object.entries(overrides)
@@ -493,6 +493,13 @@ async function applyPackageOverrides(
 		pkg.pnpm.overrides = {
 			...pkg.pnpm.overrides,
 			...overrides,
+		}
+
+		if (pkg.packageManager?.includes('pnpm@10')) {
+			pkg.packageManager = 'pnpm@9.15.9'
+			if (pkg.engines?.pnpm) {
+				pkg.engines.pnpm = '>=9.15.9'
+			}
 		}
 	} else if (pm === 'yarn') {
 		if (!pkg.devDependencies) {

--- a/utils.ts
+++ b/utils.ts
@@ -460,7 +460,7 @@ async function applyPackageOverrides(
 	beforeInstallCommand: ((scripts: any) => Promise<any>) | void,
 ) {
 	const useFileProtocol = (v: string) =>
-		isLocalOverride(v) ? `file:${path.resolve(v)}` : v
+		isLocalOverride(v) ? path.resolve(v) : v
 	// remove boolean flags
 	overrides = Object.fromEntries(
 		Object.entries(overrides)
@@ -493,13 +493,6 @@ async function applyPackageOverrides(
 		pkg.pnpm.overrides = {
 			...pkg.pnpm.overrides,
 			...overrides,
-		}
-
-		if (pkg.packageManager?.includes('pnpm@10')) {
-			pkg.packageManager = 'pnpm@9.15.9'
-			if (pkg.engines?.pnpm) {
-				pkg.engines.pnpm = '>=9.15.9'
-			}
 		}
 	} else if (pm === 'yarn') {
 		if (!pkg.devDependencies) {


### PR DESCRIPTION
The lynx-stack includes the core framework and toolset for [Lynx](https://lynxjs.org/index.html).

We heavily depends on Rstack:

- `@lynx-js/*-webpack-plugin`: A collection of Webpack and **Rspack** plugins.
- `@lynx-js/webpack-test-tools`: use **`@rspack/test-tools`**.
- `@lynx-js/rspeedy`: Built directly on **Rsbuild** with built-in **Rsdoctor** plugin.
- Most packages are developed using **Rslib**.
- The website is using **Rspress**.

Integrating the lynx-stack into the Rspack Ecosystem CI would be a valuable enhancement.

Following up to #75.
