### PR TITLE
fix: add `--no-strict-peer-dependencies` for pnpm

### DIFF
--- a/utils.ts
+++ b/utils.ts
@@ -537,7 +537,7 @@ async function applyPackageOverrides(
 
 	// use of `ni` command here could cause lockfile violation errors so fall back to native commands that avoid these
 	if (pm === 'pnpm') {
-		await $`pnpm install --prefer-frozen-lockfile --prefer-offline`
+		await $`pnpm install --prefer-frozen-lockfile --prefer-offline --no-strict-peer-dependencies`
 	} else if (pm === 'yarn') {
 		await $`yarn install`
 	} else if (pm === 'npm') {


### PR DESCRIPTION
Add `--no-strict-peer-dependencies` to `pnpm install` to avoid error on installing lynx-stack.

See: https://github.com/web-infra-dev/rspack/actions/runs/16134954805/job/45529673975