### PR TITLE
chore: add 'build:rslib' command to rspack-examples repo

### DIFF
--- a/tests/examples.ts
+++ b/tests/examples.ts
@@ -12,6 +12,7 @@ export async function test(options: RunOptions) {
 			'build:rsbuild',
 			'build:rsdoctor',
 			'build:rspress',
+			'build:rslib',
 		],
 	})
 }


### PR DESCRIPTION
This pull request makes a minor update to the build process in the `tests/examples.ts` file. The change adds the `build:rslib` command to the list of scripts executed during testing.

* Added `build:rslib` to the array of build scripts in the `test` function to ensure it is included in the test build process.